### PR TITLE
ordering the list of courses by year

### DIFF
--- a/controllers/courseController.js
+++ b/controllers/courseController.js
@@ -390,7 +390,7 @@ exports.showCourses = async (req, res) => {
       instructor: 1,
       institution: 1,
     }
-  );
+  ).sort({year: -1});
 
   res.render("./pages/course-pastList", {
     courseTimes: courseTimes,


### PR DESCRIPTION
This adjustment ensures that when the pastList page is rendered, the courses will be listed from the most recent year to the oldest.