### PR TITLE
"removing visibility of start and end times for now while fixing them"

### DIFF
--- a/views/pages/events-private.ejs
+++ b/views/pages/events-private.ejs
@@ -73,7 +73,7 @@
                       <%= futureEventsInfo[i].start %>
                     </p>
                   </li>
-                  <li
+                  <!-- <li
                     class="list-group-item borderless box-padding bg-transparent"
                     style="font-size: large">
                     <h5 style="display: inline; font-weight: 650">
@@ -90,7 +90,7 @@
                     <p style="display: inline" class="TZChange1">
                       <%= futureEventsInfo[i].end %>
                     </p>
-                  </li>
+                  </li> -->
                   <% } %> <% if (futureEventsInfo[i].uri !== null) { %>
                   <li
                     class="list-group-item borderless box-padding bg-transparent"
@@ -216,7 +216,7 @@
                       <%= pastEventsInfo[i].start %>
                     </p>
                   </li>
-                  <li
+                  <!-- <li
                     class="list-group-item borderless box-padding bg-transparent"
                     style="font-size: large">
                     <h5 style="display: inline; font-weight: 650">
@@ -233,7 +233,7 @@
                     <p style="display: inline" class="TZChange1">
                       <%= pastEventsInfo[i].end %>
                     </p>
-                  </li>
+                  </li> -->
                   <% } %> <% if (pastEventsInfo[i].uri !== null) { %>
                   <li
                     class="list-group-item borderless box-padding bg-transparent"

--- a/views/pages/events-public.ejs
+++ b/views/pages/events-public.ejs
@@ -56,7 +56,7 @@
                                                     <p style="display: inline"
                                                         class="TZChange"><%= futureEventsInfo[i].start %></p>    
                                                 </li>
-                                                <li class='list-group-item borderless box-padding bg-transparent'
+                                                <!-- <li class='list-group-item borderless box-padding bg-transparent'
                                                     style="font-size: large">
                                                     <h5 style="display: inline; font-weight: 650">Start time: </h5>
                                                     <p style="display: inline;"
@@ -67,7 +67,7 @@
                                                     <h5 style="display: inline; font-weight: 650">End time: </h5>
                                                     <p style="display: inline;"
                                                         class="TZChange1"><%= futureEventsInfo[i].end %></p>
-                                                </li>
+                                                </li> -->
                                             <% } %>
                                             <% if (futureEventsInfo[i].uri !== null) { %>
                                                 <li class='list-group-item borderless box-padding bg-transparent'
@@ -132,7 +132,7 @@
                                                     <p style="display: inline"
                                                         class="TZChange"><%= pastEventsInfo[i].start %></p>
                                                 </li>
-                                                <li class='list-group-item borderless box-padding bg-transparent'
+                                                <!-- <li class='list-group-item borderless box-padding bg-transparent'
                                                     style="font-size: large">
                                                     <h5 style="display: inline; font-weight: 650">Start time: </h5>
                                                     <p style="display: inline;"
@@ -143,7 +143,7 @@
                                                     <h5 style="display: inline; font-weight: 650">End time: </h5>
                                                     <p style="display: inline;"
                                                         class="TZChange1"><%= pastEventsInfo[i].end %></p>
-                                                </li>
+                                                </li> -->
                                             <% } %>
                                             <% if (pastEventsInfo[i].uri !== null) { %>
                                                 <li class='list-group-item borderless box-padding bg-transparent'


### PR DESCRIPTION
- they will be re-added again after proper parsing of the date and time format for the Safari browser are applied.